### PR TITLE
Skip Level 1 Mod

### DIFF
--- a/HouseRules.Essentials/Rules/LevelSequenceOverriddenRule.cs
+++ b/HouseRules.Essentials/Rules/LevelSequenceOverriddenRule.cs
@@ -1,4 +1,4 @@
-﻿namespace HouseRules.Essentials.Rules
+namespace HouseRules.Essentials.Rules
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -15,6 +15,7 @@
 
         private static bool isRandomMaps;
         private static bool isFastForward;
+        private static bool isSkipLevel1;
         private static List<string> _globalAdjustments;
         private static List<string> _randomMaps = new List<string>
                     { string.Empty, string.Empty, string.Empty, string.Empty, string.Empty };
@@ -212,11 +213,17 @@
             {
                 isRandomMaps = true;
                 isFastForward = false;
+                isSkipLevel1 = false;
                 if (replacements[0].Contains("fastforward"))
                 {
                     isFastForward = true;
                     HouseRulesEssentialsBase.LogWarning("Fast Forward mode detected");
                 }
+                if (replacements[0].Contains("skiplevel1"))
+                {
+                    isSkipLevel1 = true;
+                    HouseRulesEssentialsBase.LogWarning("Skip Level 1 mode detected");
+                }                
             }
 
             int rndLevel = Random.Range(1, 6);
@@ -484,7 +491,10 @@
                     case LevelSequence.GameType.Town:
                         _randomMaps[0] = "CryptEntrance";
                         _randomMaps[1] = "ForestShopFloor";
-                        _randomMaps[2] = "TownsEntrance";
+                        if (!isSkipLevel1)
+                        {
+                            _randomMaps[2] = "TownsEntrance";                        
+                        }
                         _randomMaps[3] = "ForestShopFloor";
                         break;
                     case LevelSequence.GameType.ElvenQueen:
@@ -492,13 +502,19 @@
                     case LevelSequence.GameType.Desert:
                         _randomMaps[0] = "TownsEntrance";
                         _randomMaps[1] = "ForestShopFloor";
-                        _randomMaps[2] = "TownsEntrance";
+                        if (!isSkipLevel1)
+                        {                        
+                            _randomMaps[2] = "TownsEntrance";
+                        }
                         _randomMaps[3] = "ForestShopFloor";
                         break;
                     case LevelSequence.GameType.Forest:
-                        _randomMaps[0] = "ElvenFloor15";
+                        _randomMaps[0] = "TownsEntrance";
                         _randomMaps[1] = "ForestShopFloor";
-                        _randomMaps[2] = "ElvenFloor15";
+                        if (!isSkipLevel1)
+                        {                        
+                            _randomMaps[2] = "ElvenFloor15";
+                        }
                         _randomMaps[3] = "ForestShopFloor";
                         break;
                 }


### PR DESCRIPTION
Allow a user to skip only the first level by using the string `skiplevel1` as the first entry in the  `LevelSequenceOverridden` Rule in the JSON file. For example:

```json
    {
      "Rule": "LevelSequenceOverridden",
      "Config": [
        "skiplevel1",
        "SewersFloor08",
        "SewersFloor11",
        "ForestFloor02",
        "ForestFloor01",
        "ElvenFloor14"
      ]
    },
```

Existing functionality to skip both level 1 and level 2 remains unchanges using the `fastforward` string. For example:

```json
    {
      "Rule": "LevelSequenceOverridden",
      "Config": [
        "fastforward",
        "SewersFloor08",
        "SewersFloor11",
        "ForestFloor02",
        "ForestFloor01",
        "ElvenFloor14"
      ]
    },
```